### PR TITLE
add Telegram-Card

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1470,6 +1470,18 @@ Generating NPM or GitHub status for profile README.
 
 ---
 
+### 87 . [Telegram Card](https://github.com/Malith-Rukshan/telegram-card)
+Dynamic preview card generator for Telegram channels, groups, and bots. Features responsive design, dark/light theme support, and displays subscriber/member/monthly users/online users counts. Perfect for GitHub profiles and portfolios.
+
+📍 For example :
+| ![Preivew Item](https://telegram-card.vercel.app/?username=AlphaV2ray&theme=light) | ![Preivew Item](https://telegram-card.vercel.app/?username=SingleMusicX) |
+|------------|-----------|
+| ![Preivew Item](https://telegram-card.vercel.app/?username=MOD_APPS_Stock) | ![Preivew Item](https://telegram-card.vercel.app/?username=QuizUpLK) |
+| ![Preivew Item](https://telegram-card.vercel.app/?username=ReceiveSMSRobot&theme=light) | ![Preivew Item](https://telegram-card.vercel.app/?username=Alpha_V2ray) |
+![Telegram Channel](https://telegram-card.vercel.app/?username=durov&theme=dark) | ![Telegram Channel](https://telegram-card.vercel.app/?username=Premium&theme=dark)
+
+---
+
 </details>
   
 ## ✅ Icons 👇


### PR DESCRIPTION
I'd like to add my Telegram Card Widget tool to the Widgets section of the Beautify GitHub Profile repository.

### Checklist:

- [x] The entry follows the numbering format (next available number in the list)
- [x] I searched for previous suggestions and this is not a duplicate
- [x] The entry is placed at the bottom of the widgets list as per contribution guidelines
- [x] The description is short, simple, but descriptive
- [x] The description starts with a capital letter and has proper punctuation
- [x] I've included example images as shown in other entries
- [x] I've used the correct GitHub link with the #readme anchor

| ![Preivew Item](https://telegram-card.vercel.app/?username=AlphaV2ray&theme=light) | ![Preivew Item](https://telegram-card.vercel.app/?username=SingleMusicX) |
|------------|-----------|
| ![Preivew Item](https://telegram-card.vercel.app/?username=MOD_APPS_Stock) | ![Preivew Item](https://telegram-card.vercel.app/?username=QuizUpLK) |
| ![Preivew Item](https://telegram-card.vercel.app/?username=ReceiveSMSRobot&theme=light) | ![Preivew Item](https://telegram-card.vercel.app/?username=Alpha_V2ray) |
![Telegram Channel](https://telegram-card.vercel.app/?username=durov&theme=dark) | ![Telegram Channel](https://telegram-card.vercel.app/?username=Premium&theme=dark)