### PR TITLE
Add GitHub PR Stats to Widgets section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1482,6 +1482,20 @@ Dynamic preview card generator for Telegram channels, groups, and bots. Features
 
 ---
 
+### 88 . [GitHub PR Stats](https://github.com/f14XuanLv/github-pr-stats)
+
+Dynamic SVG tables displaying your GitHub pull requests with dual modes: detailed PR list and repository aggregate statistics. Features status filtering, star-based sorting, and customizable fields.
+
+📍 For example :
+
+### 📊 PR List Mode - Your Contribution Timeline
+![PR List Demo](https://github-pr-stats-five.vercel.app/api/github-pr-stats?username=f14xuanlv&limit=6&theme=dark)
+
+### 📈 Repository Stats Mode - Impact Overview
+![Repo Stats Demo](https://github-pr-stats-five.vercel.app/api/github-pr-stats?username=torvalds&mode=repo-aggregate&limit=5&theme=dark)
+
+---
+
 </details>
   
 ## ✅ Icons 👇


### PR DESCRIPTION
Adding GitHub PR Stats (#88) to the Widgets section.

GitHub PR Stats generates dynamic SVG tables displaying GitHub pull requests with dual modes: detailed PR list and repository aggregate statistics.

## Examples

### 📊 PR List Mode - Your Contribution Timeline
![PR List Demo](https://github-pr-stats-five.vercel.app/api/github-pr-stats?username=f14xuanlv&limit=6&theme=dark)

### 📈 Repository Stats Mode - Impact Overview  
![Repo Stats Demo](https://github-pr-stats-five.vercel.app/api/github-pr-stats?username=torvalds&mode=repo-aggregate&limit=5&theme=dark)
*Using Linux creator Linus Torvalds' public PR data for technical demonstration*

## Add Link of GitHub Profile

https://github.com/f14XuanLv
