### PR TITLE
fix: update Repo Roster links

### DIFF
--- a/readme-fa.md
+++ b/readme-fa.md
@@ -1393,19 +1393,19 @@ Moon.svg فاز فعلی ماه را به صورت لحظه‌ای نمایش م
   <img src="https://i.countdownmail.com/2kjo3y.gif" border="0" alt="countdownmail.com"/>  
 </p>  
 
-### 76. [Repo Roster](https://reporoster.com//)  
+### 76. [Repo Roster](http://reporoster.com/)  
 تشکر از حامیان خود در فایل README گیت‌هاب.
 
 📍 به عنوان مثال:  
 
 > ستارگان  
 <p align="center">  
-  <img src="https://reporoster.com/stars/rzashakeri/beautify-github-profile" border="0" alt="https://github.com/rzashakeri/beautify-github-profile/stargazers"/>  
+  <img src="http://reporoster.com/stars/rzashakeri/beautify-github-profile" border="0" alt="https://github.com/rzashakeri/beautify-github-profile/stargazers"/>  
 </p>  
 
 > فورکرها  
 <p align="center">  
-  <img src="https://reporoster.com/forks/rzashakeri/beautify-github-profile" border="0" alt="https://github.com/rzashakeri/beautify-github-profile/network/members"/>  
+  <img src="http://reporoster.com/forks/rzashakeri/beautify-github-profile" border="0" alt="https://github.com/rzashakeri/beautify-github-profile/network/members"/>  
 </p>  
 
 ### 77. [Moe Counter](https://github.com/journey-ad/Moe-Counter)  

--- a/readme.md
+++ b/readme.md
@@ -1375,19 +1375,19 @@ The countdown timer is based on the end date and time in a specific time zone.
   <img src="https://i.countdownmail.com/2kjo3y.gif" border="0" alt="countdownmail.com"/>
 </p>
 
-### 76 . [Repo Roster](https://reporoster.com//)
+### 76 . [Repo Roster](http://reporoster.com/)
 Shout-out supporters in your GitHub README file.
 
 📍 For example :
 
 > Stargazers
 <p align="center">
-  <img src="https://reporoster.com/stars/rzashakeri/beautify-github-profile" border="0" alt="https://github.com/rzashakeri/beautify-github-profile/stargazers"/>
+  <img src="http://reporoster.com/stars/rzashakeri/beautify-github-profile" border="0" alt="https://github.com/rzashakeri/beautify-github-profile/stargazers"/>
 </p>
 
 > Forkers
 <p align="center">
-  <img src="https://reporoster.com/forks/rzashakeri/beautify-github-profile" border="0" alt="https://github.com/rzashakeri/beautify-github-profile/network/members"/>
+  <img src="http://reporoster.com/forks/rzashakeri/beautify-github-profile" border="0" alt="https://github.com/rzashakeri/beautify-github-profile/network/members"/>
 </p>
 
 ### 77 . [Moe Counter](https://github.com/journey-ad/Moe-Counter)


### PR DESCRIPTION
Fixes #94

## Summary
- Update the Repo Roster README links to use the working HTTP endpoint instead of the expired HTTPS endpoint
- Apply the same fix to the Farsi README

## Verification
- Confirmed `http://reporoster.com/` returns HTTP 200
- Confirmed the Repo Roster stars and forks SVG endpoints return HTTP 200