### PR TITLE
fix: replace broken star history image link

### DIFF
--- a/readme-fa.md
+++ b/readme-fa.md
@@ -1421,7 +1421,7 @@ Moon.svg فاز فعلی ماه را به صورت لحظه‌ای نمایش م
 
 📍 به عنوان مثال:  
 <p align="center">  
-  <img src="https://api.lucabubi.me/chart?username=mdn&repository=js-examples&color=red" alt="Red Chart">  
+  <img src="https://api.star-history.com/svg?repos=mdn/js-examples&type=Date" alt="Red Chart">  
 </p>  
 
 ### 79. [Subreddit Memes](https://github.com/trinib/Subreddit-Memes)  

--- a/readme.md
+++ b/readme.md
@@ -1403,7 +1403,7 @@ A Stunning star history chart generator for Github Repositories
 
 📍 For example :
 <p align="center">
-  <img src="https://api.lucabubi.me/chart?username=mdn&repository=js-examples&color=red" alt="Red Chart">
+  <img src="https://api.star-history.com/svg?repos=mdn/js-examples&type=Date" alt="Red Chart">
 </p>
 
 ### 79 . [Subreddit Memes](https://github.com/trinib/Subreddit-Memes)


### PR DESCRIPTION
Fixes #95

## Summary
- replace the dead `api.lucabubi.me` Star History example image URL with the working `api.star-history.com` SVG endpoint
- update both English and Farsi README files

## Verification
- confirmed the old URL fails DNS resolution
- confirmed the new SVG URL returns HTTP 200 with `image/svg+xml`
